### PR TITLE
chore: freeze web server dependency versions for IT

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -20,6 +20,11 @@ java.common_templates(excludes=[
     '.gitignore',
     '.github/CODEOWNERS',
     '.github/blunderbuss.yml',
+    # README.md is excluded because its structure differs from usual template
+    # of the client libraries
     'README.md',
     'CONTRIBUTING.md',
+    # renovate.json is excluded to preserve fixed versions for web server dependencies
+    # used for integration tests
+    'renovate.json'
 ])

--- a/renovate.json
+++ b/renovate.json
@@ -51,7 +51,10 @@
         "^com.google.truth:truth",
         "^org.mockito:mockito-core",
         "^org.objenesis:objenesis",
-        "^com.google.cloud:google-cloud-conformance-tests"
+        "^com.google.cloud:google-cloud-conformance-tests",
+        "^org.eclipse.jetty:",
+        "^org.apache.tomcat.embed:tomcat-embed-core",
+        "^io.undertow:"        
       ],
       "semanticCommitType": "test",
       "semanticCommitScope": "deps"


### PR DESCRIPTION
Freeze versions of web server packages in the test scope to support a baseline (per web server) of supported versions.

Note: Documentation (in README) will be provided in a separate PR.