### PR TITLE
chore: fix version typo

### DIFF
--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging-servlet-initializer</artifactId>
-      <version>0.1.0-aplha</version>
+      <version>0.1.0-alpha</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Fix typo in the version name that leads to failed nightly builds.