### PR TITLE
chore: fix release versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
 # Changelog
 
-### [0.1.2](https://github.com/googleapis/java-logging-servlet-initializer/compare/v0.1.1...v0.1.2) (2022-01-15)
+### [0.1.3-alpha](https://github.com/googleapis/java-logging-servlet-initializer/compare/v0.1.2-alpha...0.1.3-alpha) (2022-01-15)
 
 
 ### Dependencies
 
 * update dependency com.google.cloud:google-cloud-logging to v3.6.0 ([#42](https://github.com/googleapis/java-logging-servlet-initializer/issues/42)) ([c05396c](https://github.com/googleapis/java-logging-servlet-initializer/commit/c05396c54ea14c3346a51784bdc50d7a3b570f85))
 
-### [0.1.1](https://www.github.com/googleapis/java-logging-servlet-initializer/compare/v0.1.0...v0.1.1) (2022-01-10)
+### [0.1.2-alpha](https://www.github.com/googleapis/java-logging-servlet-initializer/compare/v0.1.1-alpha...v0.1.2-alpha) (2022-01-10)
 
 
 ### Dependencies
 
 * update dependency com.google.cloud:google-cloud-logging to v3.5.3 ([#36](https://www.github.com/googleapis/java-logging-servlet-initializer/issues/36)) ([416991e](https://www.github.com/googleapis/java-logging-servlet-initializer/commit/416991e5cf21f1b5c5b3887ac877356be8fa6372))
 
-## [0.1.0](https://www.github.com/googleapis/java-logging-servlet-initializer/compare/v0.1.0-alpha...v0.1.0) (2022-01-07)
+## [0.1.1-alpha](https://www.github.com/googleapis/java-logging-servlet-initializer/compare/v0.1.0-alpha...v0.1.1-alpha) (2022-01-07)
 
 
 ### Bug Fixes


### PR DESCRIPTION
This should fix the next proposed version tag. We'll have to go back and fix the misaligned tags.

Release-As: 0.1.4-alpha