### PR TITLE
chore: exclude requirements.txt file from renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     ":maintainLockFilesDisabled",
     ":autodetectPinVersions"
   ],
+  "ignorePaths": [".kokoro/requirements.txt"],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
Manually brings in changes from https://github.com/googleapis/synthtool/pull/1594. [Renovate.json is excluded in owlbot](https://github.com/googleapis/java-logging-servlet-initializer/blob/5203283fb1fcc1d83065f72019aa07f9e5d25570/owlbot.py#L29) so the changes in synthtool couldn't be applied. 