### PR TITLE
update to servlet API v6 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ follow the
 
 ## Other dependencies
 
-The library uses Jakarta Servlet package version 4.0.4. Older versions of `javax.servlet` are not supported.
+The library uses Jakarta Servlet package version 6.0.0. Older versions of `javax.servlet` are not supported.  
+v0.2.13-alpha is the last version that builds on the Servlet API version 4.0.4. 
 
 ### For new development
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,10 @@
   <properties>
     <easymock.version>5.0.1</easymock.version>
     <logging.version>3.13.2</logging.version>
-    <jakarta.servlet.api.version>4.0.4</jakarta.servlet.api.version>  
-    <jetty.version>9.4.44.v20210927</jetty.version>
-    <tomcat.version>9.0.69</tomcat.version>
-    <undertow.version>2.2.7.Final</undertow.version>
+    <jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
+    <jetty.version>11.0.12</jetty.version>
+    <tomcat.version>10.1.1</tomcat.version>
+    <undertow.version>2.3.0.Final</undertow.version>
     <junit.version>4.13.2</junit.version>
   </properties>
 

--- a/src/main/java/com/google/cloud/logging/servlet/ContextCaptureInitializer.java
+++ b/src/main/java/com/google/cloud/logging/servlet/ContextCaptureInitializer.java
@@ -16,13 +16,14 @@
 
 package com.google.cloud.logging.servlet;
 
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterRegistration.Dynamic;
+import jakarta.servlet.ServletContainerInitializer;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+
 import java.util.EnumSet;
 import java.util.Set;
-import javax.servlet.DispatcherType;
-import javax.servlet.FilterRegistration.Dynamic;
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 
 public class ContextCaptureInitializer implements ServletContainerInitializer {
 

--- a/src/main/java/com/google/cloud/logging/servlet/RequestContextFilter.java
+++ b/src/main/java/com/google/cloud/logging/servlet/RequestContextFilter.java
@@ -20,12 +20,13 @@ import com.google.cloud.logging.Context;
 import com.google.cloud.logging.ContextHandler;
 import com.google.cloud.logging.HttpRequest;
 import com.google.common.base.Strings;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpFilter;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 public class RequestContextFilter extends HttpFilter {
   private static final long serialVersionUID = 1517497440413815384L;

--- a/src/test/java/com/google/cloud/logging/servlet/ContextCaptureInitializerTest.java
+++ b/src/test/java/com/google/cloud/logging/servlet/ContextCaptureInitializerTest.java
@@ -16,18 +16,19 @@
 
 package com.google.cloud.logging.servlet;
 
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterRegistration;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import org.junit.Test;
+
+import java.util.EnumSet;
+
 import static org.easymock.EasyMock.createStrictMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-
-import java.util.EnumSet;
-import javax.servlet.DispatcherType;
-import javax.servlet.FilterRegistration.Dynamic;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import org.junit.Test;
 
 public class ContextCaptureInitializerTest {
 
@@ -38,7 +39,7 @@ public class ContextCaptureInitializerTest {
   @Test
   public void testRegistration() throws ServletException {
     ServletContext mockedServletContext = createStrictMock(ServletContext.class);
-    Dynamic mockedDynamic = createStrictMock(Dynamic.class);
+    FilterRegistration.Dynamic mockedDynamic = createStrictMock(FilterRegistration.Dynamic.class);
     expect(mockedServletContext.addFilter("RequestContextFilter", RequestContextFilter.class))
         .andReturn(mockedDynamic)
         .once();

--- a/src/test/java/com/google/cloud/logging/servlet/RequestContextFilterTest.java
+++ b/src/test/java/com/google/cloud/logging/servlet/RequestContextFilterTest.java
@@ -29,10 +29,11 @@ import com.google.cloud.logging.Context;
 import com.google.cloud.logging.ContextHandler;
 import com.google.cloud.logging.HttpRequest;
 import java.io.IOException;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/google/cloud/logging/servlet/it/ITContainersTest.java
+++ b/src/test/java/com/google/cloud/logging/servlet/it/ITContainersTest.java
@@ -30,10 +30,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
-import javax.servlet.AsyncContext;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;

--- a/src/test/java/com/google/cloud/logging/servlet/it/container/JettyContainer.java
+++ b/src/test/java/com/google/cloud/logging/servlet/it/container/JettyContainer.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.logging.servlet.it.container;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletContainerInitializer;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletContainerInitializer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;

--- a/src/test/java/com/google/cloud/logging/servlet/it/container/ServletContainer.java
+++ b/src/test/java/com/google/cloud/logging/servlet/it/container/ServletContainer.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.logging.servlet.it.container;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletContainerInitializer;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletContainerInitializer;
 
 public interface ServletContainer {
   void start() throws Exception;

--- a/src/test/java/com/google/cloud/logging/servlet/it/container/TomcatContainer.java
+++ b/src/test/java/com/google/cloud/logging/servlet/it/container/TomcatContainer.java
@@ -18,8 +18,9 @@ package com.google.cloud.logging.servlet.it.container;
 
 import java.io.File;
 import java.util.Collections;
-import javax.servlet.Servlet;
-import javax.servlet.ServletContainerInitializer;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletContainerInitializer;
 import org.apache.catalina.Context;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.startup.Tomcat;

--- a/src/test/java/com/google/cloud/logging/servlet/it/container/UndertowContainer.java
+++ b/src/test/java/com/google/cloud/logging/servlet/it/container/UndertowContainer.java
@@ -27,9 +27,10 @@ import io.undertow.server.handlers.PathHandler;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
 import io.undertow.servlet.api.ServletContainerInitializerInfo;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletContainerInitializer;
+
 import java.util.Collections;
-import javax.servlet.Servlet;
-import javax.servlet.ServletContainerInitializer;
 
 public class UndertowContainer implements ServletContainer {
   private Undertow server;


### PR DESCRIPTION
tried to use latest server versions everywhere, tomcat 10.1.2 is buggy though https://bz.apache.org/bugzilla/show_bug.cgi?id=66353 so 10.1.1 it is

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-logging-servlet-initializer/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #283  ☕️
relates to #161 
