### PR TITLE
ci: javadoc as a required check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -16,6 +16,7 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - cla/google
       - OwlBot Post Processor
+      - javadoc
   - pattern: java7
     isAdminEnforced: true
     requiredApprovingReviewCount: 1


### PR DESCRIPTION
Manual configuration of the required check at Settings tab has been reverted. Adding that back via sync-repo-settings.yaml.
