### PR TITLE
deps: latest google-cloud-shared-config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.5.6</version>
+    <version>1.16.1</version>
   </parent>
 
   <developers>


### PR DESCRIPTION
The latest google-cloud-shared-config has the profile to turn off
nexus-staging-maven-plugin. I confirmed the effect:

```
suztomo@suztomo2:~/java-logging-servlet-initializer$ mvn clean deploy -V     -DaltDeploymentRepository=local::default::file:${local_staging_dir}     -DskipTests=true     -P=-release-sonatype     -P=-release-staging-repository     -P=-clirr-compatibility-check     -P=-checkstyle-tests     -P=-animal-sniffer
```
