### PR TITLE
chore: remove api-logging teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# @googleapis/yoshi-java are the default owners for changes in this repo
-*                       @googleapis/yoshi-java
+# @googleapis/cloud-java-team-teamsync are the default owners for changes in this repo
+*                       @googleapis/cloud-java-team-teamsync
 
 # @googleapis/java-samples-reviewers teams are the default owners for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,8 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# @googleapis/yoshi-java @googleapis/api-logging @googleapis/api-logging-partners are the default owners for changes in this repo
-*                       @googleapis/yoshi-java @googleapis/api-logging @googleapis/api-logging-partners
-**/*.java               @googleapis/api-logging @googleapis/api-logging-partners
+# @googleapis/yoshi-java are the default owners for changes in this repo
+*                       @googleapis/yoshi-java
 
-# @googleapis/java-samples-reviewers @googleapis/api-logging @googleapis/api-logging-partners teams are the default owners for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers @googleapis/api-logging @googleapis/api-logging-partners
+# @googleapis/java-samples-reviewers teams are the default owners for samples changes
+samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,9 +1,9 @@
 # Configuration for the Blunderbuss GitHub app. For more info see
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/blunderbuss
 assign_issues:
-  - googleapis/yoshi-java
+  - googleapis/cloud-java-team-teamsync
 assign_prs:
-  - googleapis/yoshi-java
+  - googleapis/cloud-java-team-teamsync
 assign_prs_by:
   - labels:
     - samples

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,9 +1,9 @@
 # Configuration for the Blunderbuss GitHub app. For more info see
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/blunderbuss
 assign_issues:
-  - googleapis/api-logging-java-reviewers
+  - googleapis/yoshi-java
 assign_prs:
-  - googleapis/api-logging-java-reviewers
+  - googleapis/yoshi-java
 assign_prs_by:
   - labels:
     - samples

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -36,5 +36,5 @@ permissionRules:
     permission: admin
   - team: yoshi-java-admins
     permission: admin
-  - team: yoshi-java
+  - team: cloud-java-team-teamsync
     permission: push

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,7 +10,7 @@
     "repo": "googleapis/java-logging-servlet-initializer",
     "repo_short": "java-logging-servlet-initializer",
     "distribution_name": "com.google.cloud:google-cloud-logging-servlet-initializer",
-    "codeowner_team": "@googleapis/yoshi-java",
+    "codeowner_team": "@googleapis/cloud-java-team-teamsync",
     "library_type": "OTHER",
     "api_id": "logging.googleapis.com"
   }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,7 +10,7 @@
     "repo": "googleapis/java-logging-servlet-initializer",
     "repo_short": "java-logging-servlet-initializer",
     "distribution_name": "com.google.cloud:google-cloud-logging-servlet-initializer",
-    "codeowner_team": "@googleapis/yoshi-java @googleapis/api-logging @googleapis/api-logging-partners",
+    "codeowner_team": "@googleapis/yoshi-java",
     "library_type": "OTHER",
     "api_id": "logging.googleapis.com"
   }


### PR DESCRIPTION
Removing @googleapis/api-logging, @googleapis/api-logging-partners, and @googleapis/api-logging-reviewers. Replaced with @googleapis/yoshi-java.

b/476446922