### PR TITLE
docs: Update the readme with the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,20 @@ If you are using Maven, add this to your pom.xml file:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-servlet-initializer</artifactId>
+  <version>v0.2.13-alpha</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging-servlet-initializer'
+implementation 'com.google.cloud:google-cloud-logging-servlet-initializer:0.2.13-alpha'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging-servlet-initializer"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging-servlet-initializer" % "0.2.13-alpha"
 ```
 
 ## Getting Started


### PR DESCRIPTION
Fixes: https://github.com/googleapis/java-logging-servlet-initializer/issues/141

Add the latest version of the library to the README. This repo is not part of the libraries-bom.